### PR TITLE
AppendChild will put pane in parent after close

### DIFF
--- a/src/cupertino-pane.ts
+++ b/src/cupertino-pane.ts
@@ -407,7 +407,6 @@ export class CupertinoPane {
       this.currentBreak = this.breaks[this.settings.initialBreak];
 
       this.paneEl.addEventListener('transitionend', (t) => {
-        this.parentEl.appendChild(this.contentEl);
         this.parentEl.removeChild(this.wrapperEl);
 
         // Emit event

--- a/src/cupertino-pane.ts
+++ b/src/cupertino-pane.ts
@@ -407,8 +407,10 @@ export class CupertinoPane {
       this.currentBreak = this.breaks[this.settings.initialBreak];
 
       this.paneEl.addEventListener('transitionend', (t) => {
+        this.parentEl.appendChild(this.contentEl);
+        this.contentEl.style.display = 'none';
         this.parentEl.removeChild(this.wrapperEl);
-
+        
         // Emit event
         this.settings.onDidDismiss();
       });


### PR DESCRIPTION
This appendChild will put the pane content in the parent replacing basically its content (in my case).
Changing this command to a removeChild neither is desireable as navigating back to the parent will show the content of the pane not in a pane. Hence this suggestion.

node_modules content of cupertino-pane adjusted for demo at https://ionicsvelte.firebaseapp.com/pane