### PR TITLE
Fix Android dragging lags

### DIFF
--- a/src/cupertino-pane.ts
+++ b/src/cupertino-pane.ts
@@ -474,6 +474,8 @@ export class CupertinoPane {
    */
   private touchStartCb = (t) => this.touchStart(t);
   private touchStart(t) {
+    t.preventDefault();
+
     // Event emitter
     this.settings.onDragStart(t as CustomEvent);
 
@@ -518,6 +520,8 @@ export class CupertinoPane {
    */
   private touchMoveCb = (t) => this.touchMove(t);
   private touchMove(t) {
+    t.preventDefault();
+
     // Event emitter
     this.settings.onDrag(t as CustomEvent);
 


### PR DESCRIPTION
I have faced this bug #56 and started an investigation. I came down to a bare bone html-css-js simple code and I had terrible lags even with almost zero code. Even without Cordova, just a pure webpage.

After researching for a while - this is what I found. Google developer's [explanation](https://developers.google.com/web/updates/2014/05/A-More-Compatible-Smoother-Touch) about new (year 2014) touchmove behavior.

TDLR: Google Chrome fires one touchmove event per 200ms, which gives your drawer 5 FPS. To prevent this, you must fire `e.preventDefault` on touchstart event. In case of cupertino-pane I have to do it in touchmove event as well for some reason.

This PR should fix lagginess on Android devices.